### PR TITLE
Fix automatic recovery when using sockets

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ fi
 # Check for exit code 101 and RECOVER_AUTOMATICALLY flag
 if [ "$exit_code" -eq 101 ]; then
     if [ "$RECOVER_AUTOMATICALLY" -eq 1 ]; then
-        echo -e "RECOVER_AUTOMATICALLY=1 so attempting to automatically recover by dropping state_compressor_progress, state_compressor_state, and state_compressor_total_progress tables."
+        echo "RECOVER_AUTOMATICALLY=1 so attempting to automatically recover by dropping state_compressor_progress, state_compressor_state, and state_compressor_total_progress tables."
         # Drop specified tables using the local psql command
         psql -d "$POSTGRES_LOCATION" -c "DROP TABLE state_compressor_progress; DROP TABLE state_compressor_state; DROP TABLE state_compressor_total_progress;"
     else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$exit_code" -eq 101 ]; then
     if [ "$RECOVER_AUTOMATICALLY" -eq 1 ]; then
         echo -e "RECOVER_AUTOMATICALLY=1 so attempting to automatically recover by dropping state_compressor_progress, state_compressor_state, and state_compressor_total_progress tables."
         # Drop specified tables using the local psql command
-        PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER -d $POSTGRES_DB -c "DROP TABLE state_compressor_progress; DROP TABLE state_compressor_state; DROP TABLE state_compressor_total_progress;"
+        psql -d "$POSTGRES_LOCATION" -c "DROP TABLE state_compressor_progress; DROP TABLE state_compressor_state; DROP TABLE state_compressor_total_progress;"
     else
         echo "The compressor encountered an error, check the logs above for more details."
         echo "If recovery is needed, consider dropping the tables state_compressor_progress, state_compressor_state, and state_compressor_total_progress in the Synapse database, which you can do automatically by setting RECOVER_AUTOMATICALLY=1 in this container's environment variables."


### PR DESCRIPTION
Automatic recovery didn't use the constructed connection string, but would manually pass the tcp connection variables.
This fails with the following error when sockets are used:
```
RECOVER_AUTOMATICALLY=1 so attempting to automatically recover by dropping state_compressor_progress, state_compressor_state, and state_compressor_total_progress tables.
psql: error: connection to server at "127.0.0.1", port 5432 failed: Connection refused
        Is the server running on that host and accepting TCP/IP connections?
```
 Use the connection string instead.